### PR TITLE
Downgrade ddp-builder container version

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /usr/src/sriov-network-device-plugin
 RUN make clean && \
     make build
 
-FROM golang:1.21-alpine3.19 as ddp-builder
+FROM golang:1.20-alpine3.16 as ddp-builder
 
 ADD images/ddptool-1.0.1.12.tar.gz /tmp/ddptool/
 


### PR DESCRIPTION
Upgrading to golang:1.21-alpine3.19 caused the ddp build to fail. Downgrade it until the root cause is found